### PR TITLE
services: Add  `podAntiAffinity`

### DIFF
--- a/poll.deployment.yaml
+++ b/poll.deployment.yaml
@@ -30,3 +30,13 @@ spec:
               name: "kube-config-poll"
         ports:
           - containerPort: 80
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: services
+                    operator: In
+                    values:
+                      - poll
+              topologyKey: kubernetes.io/hostname

--- a/result.deployment.yaml
+++ b/result.deployment.yaml
@@ -16,6 +16,16 @@ spec:
       labels:
         services: "result"
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: services
+                    operator: In
+                    values:
+                      - result
+              topologyKey: kubernetes.io/hostname
       restartPolicy: Always
       containers:
       - name: "t-dop-600-result-1"


### PR DESCRIPTION
- Add podAntiAffinity to both `poll` and `result` deployment
- Missing:
    - traefik

> Pod anti-affinity can prevent the scheduler from locating a new pod on the same node as pods with the same labels if the label selector on the new pod matches the label on the current pod.